### PR TITLE
Redeem pynodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,15 @@ for page in parsed_database:
 **NotionDatabaseClient**  
 This module is for using Notion API. You can fetch, update Notion database and create, update Notion pages using this module.  
 
-| Method              | Parameter                   | Description                                                                 |
-|---------------------|-----------------------------|-----------------------------------------------------------------------------|
-| fetch_database()    | `limit(=None)`, `filter(=None)` | Fetch all data from database. You can set limit(number of pages you want) and filter(query condition, please see this [link](https://developers.notion.com/reference/post-database-query)) for this method. |
-| update_database()   | `data`(json type body)| Update database. Please see this [link](https://developers.notion.com/reference/update-a-database) for `data` parameter. |
-| create_page()       | `data`(json type body)| Create page. Please see this [link](https://developers.notion.com/reference/post-page) for `data` parameter. |
-| update_page()       | `page_id`, `data`(json type body)| Update page. Please see this [link](https://developers.notion.com/reference/patch-page) for `data` parameter. |
-| get_page()          | `page_id` | Retrieve a page. Please see this [link](https://developers.notion.com/reference/retrieve-a-page). |
-| get_block_children()| `block_id` | Retrieve a block. Please see this [link](https://developers.notion.com/reference/retrieve-a-block). |
+| Method                 | Parameter                   | Description                                                                 |
+|------------------------|-----------------------------|-----------------------------------------------------------------------------|
+| fetch_database()       | `limit(=None)`, `filter(=None)` | Fetch all data from database. You can set limit(number of pages you want) and filter(query condition, please see this [link](https://developers.notion.com/reference/post-database-query)) for this method. |
+| update_database()      | `data`(json type body)| Update database. Please see this [link](https://developers.notion.com/reference/update-a-database) for `data` parameter. |
+| create_page()          | `data`(json type body)| Create page. Please see this [link](https://developers.notion.com/reference/post-page) for `data` parameter. |
+| update_page()          | `page_id`, `data`(json type body)| Update page. Please see this [link](https://developers.notion.com/reference/patch-page) for `data` parameter. |
+| get_page()             | `page_id` | Retrieve a page. Please see this [link](https://developers.notion.com/reference/retrieve-a-page). |
+| get_block_children()   | `block_id` | Retrieve a block. Please see this [link](https://developers.notion.com/reference/get-block-children). |
+| append_block_children()| `block_id`, `data`(json type body)| Append block children. Please see this [link](https://developers.notion.com/reference/patch-block-children) for `data` parameter. |
 
 **DatabaseParser**  
 There are only private methods in this class. You can only access varaibles.  

--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ for page in parsed_database:
 **NotionDatabaseClient**  
 This module is for using Notion API. You can fetch, update Notion database and create, update Notion pages using this module.  
 
-| Method            | Parameter                   | Description                                                                 |
-|-------------------|-----------------------------|-----------------------------------------------------------------------------|
-| fetch_database()  | `limit(=None)`, `filter(=None)` | Fetch all data from database. You can set limit(number of pages you want) and filter(query condition, please see this [link](https://developers.notion.com/reference/post-database-query)) for this method. |
-| update_database() | `data`(json type body)| Update database. Please see this [link](https://developers.notion.com/reference/update-a-database) for `data` parameter|
-| create_page()     | `data`(json type body)| Create page. Please see this [link](https://developers.notion.com/reference/post-page) for `data` parameter|
-| update_page()     | `page_id`, `data`(json type body)| Update page. Please see this [link](https://developers.notion.com/reference/patch-page) for `data` parameter|
+| Method              | Parameter                   | Description                                                                 |
+|---------------------|-----------------------------|-----------------------------------------------------------------------------|
+| fetch_database()    | `limit(=None)`, `filter(=None)` | Fetch all data from database. You can set limit(number of pages you want) and filter(query condition, please see this [link](https://developers.notion.com/reference/post-database-query)) for this method. |
+| update_database()   | `data`(json type body)| Update database. Please see this [link](https://developers.notion.com/reference/update-a-database) for `data` parameter. |
+| create_page()       | `data`(json type body)| Create page. Please see this [link](https://developers.notion.com/reference/post-page) for `data` parameter. |
+| update_page()       | `page_id`, `data`(json type body)| Update page. Please see this [link](https://developers.notion.com/reference/patch-page) for `data` parameter. |
+| get_page()          | `page_id` | Retrieve a page. Please see this [link](https://developers.notion.com/reference/retrieve-a-page). |
+| get_block_children()| `block_id` | Retrieve a block. Please see this [link](https://developers.notion.com/reference/retrieve-a-block). |
 
 **DatabaseParser**  
 There are only private methods in this class. You can only access varaibles.  
@@ -103,5 +105,7 @@ You can get any data type using **NotionDatabaseClient** since it gives you raw 
 7. DATE
 8. URL
 9. CHECKBOX
-
+10. RELATION
+11. ROLLUP (only array type)
+12. FORMULA
 

--- a/pynodb.egg-info/PKG-INFO
+++ b/pynodb.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: pynodb
-Version: 0.1
+Version: 0.2
 Summary: UNKNOWN
 Home-page: https://github.com/GeeseBumps/pynodb
 Author: GeeseBumps

--- a/pynodb/database_parser.py
+++ b/pynodb/database_parser.py
@@ -15,6 +15,7 @@ class DatabaseParser:
             "title": lambda x: self._parse_title_value(x),
             "people": lambda x: self._parse_people_value(x),
             "relation": lambda x: self._parse_relation_value(x),
+            "rollup": lambda x: self._parse_rollup_value(x),
         }
         self.parsed_database = self._parse_database(database)
 
@@ -85,6 +86,13 @@ class DatabaseParser:
             for relation in value_data:
                 values.append(relation["id"])
             return values
+        return None
+    
+    def _parse_rollup_value(self, value_data):
+        if value_data:
+            if value_data["type"] == "array":
+                type = value_data["array"][0]["type"]
+                return value_data["array"][0][type]
         return None
     
     def _parse_database(self, database):

--- a/pynodb/database_parser.py
+++ b/pynodb/database_parser.py
@@ -16,6 +16,7 @@ class DatabaseParser:
             "people": lambda x: self._parse_people_value(x),
             "relation": lambda x: self._parse_relation_value(x),
             "rollup": lambda x: self._parse_rollup_value(x),
+            "formula": lambda x: self._parse_formula_value(x),
         }
         self.parsed_database = self._parse_database(database)
 
@@ -93,6 +94,12 @@ class DatabaseParser:
             if value_data["type"] == "array":
                 type = value_data["array"][0]["type"]
                 return value_data["array"][0][type]
+        return None
+    
+    def _parse_formula_value(self, value_data):
+        if value_data:
+            type = value_data["type"]
+            return value_data[type]
         return None
     
     def _parse_database(self, database):

--- a/pynodb/database_parser.py
+++ b/pynodb/database_parser.py
@@ -107,6 +107,7 @@ class DatabaseParser:
         for page in database:
             _temp_page = {}
             _temp_page["page_id"] = page["id"]
+            _temp_page["page_url"] = page["url"]
             for property_name in page["properties"]:
                 property_data = {}
                 property_metadata = page["properties"][property_name]

--- a/pynodb/database_parser.py
+++ b/pynodb/database_parser.py
@@ -13,7 +13,8 @@ class DatabaseParser:
             "rich_text": lambda x: self._parse_rich_text_value(x),
             "checkbox": lambda x: self._parse_checkbox_value(x),
             "title": lambda x: self._parse_title_value(x),
-            "people": lambda x: self._parse_people_value(x)
+            "people": lambda x: self._parse_people_value(x),
+            "relation": lambda x: self._parse_relation_value(x),
         }
         self.parsed_database = self._parse_database(database)
 
@@ -76,6 +77,14 @@ class DatabaseParser:
                 if value["type"] == "text":
                     text += value["plain_text"]
             return text
+        return None
+    
+    def _parse_relation_value(self, value_data):
+        if len(value_data) != 0:
+            values = []
+            for relation in value_data:
+                values.append(relation["id"])
+            return values
         return None
     
     def _parse_database(self, database):

--- a/pynodb/notion_database_client.py
+++ b/pynodb/notion_database_client.py
@@ -43,9 +43,14 @@ class NotionDatabaseClient:
 
         return response
 
-    
     def create_page(self, data):
         url = 'https://api.notion.com/v1/pages'
         response = requests.post(url, data=json.dumps(data), headers=self.headers)
+
+        return response
+    
+    def get_block_children(self, block_id):
+        notion_block_url = 'https://api.notion.com/v1/blocks/' + block_id + '/children'
+        response = requests.get(url=notion_block_url, headers=self.headers)
 
         return response

--- a/pynodb/notion_database_client.py
+++ b/pynodb/notion_database_client.py
@@ -64,4 +64,5 @@ class NotionDatabaseClient:
     def append_block_children(self, block_id, data):
         block_url = 'https://api.notion.com/v1/blocks/' + block_id + '/children'
         response = requests.patch(url=block_url, data=json.dumps(data), headers=self.headers)
+        
         return response

--- a/pynodb/notion_database_client.py
+++ b/pynodb/notion_database_client.py
@@ -54,3 +54,9 @@ class NotionDatabaseClient:
         response = requests.get(url=notion_block_url, headers=self.headers)
 
         return response
+    
+    def get_page(self, page_id):
+        notion_page_url = 'https://api.notion.com/v1/pages/' + page_id
+        response = requests.get(notion_page_url, headers=self.headers)
+
+        return response

--- a/pynodb/notion_database_client.py
+++ b/pynodb/notion_database_client.py
@@ -60,3 +60,8 @@ class NotionDatabaseClient:
         response = requests.get(notion_page_url, headers=self.headers)
 
         return response
+    
+    def append_block_children(self, block_id, data):
+        block_url = 'https://api.notion.com/v1/blocks/' + block_id + '/children'
+        response = requests.patch(url=block_url, data=json.dumps(data), headers=self.headers)
+        return response


### PR DESCRIPTION
pynodb 패키지를 잘 사용하다가 제가 필요한 부분에 대한 function이 없어 직접 만들어 보았습니다.
코드의 스타일이나 문법 등을 지적해주시면 수정하겠습니다.

## NotionDatabaseClient의 변경점
1. get_block_children() : Page 오브젝트에서 본문에 해당하는 내용입니다. [Retrieve-a-page](https://developers.notion.com/reference/retrieve-a-page)로는 property만 가져올 수 있고 본문을 가져 올 수 없기에 추가하였습니다.
2. get_page() : updata_page 함수에 data={}으로 실행하면 같은 결과를 얻을 수 있으나, 코드의 가독성을 높이기 위해 추가하였습니다.
3. append_block_children() : Page 오브젝트의 본문에 해당하는 내용을 직접 추가하는 함수입니다.

## DatabaseParser의 변경점
1. Relation, Rollup 추가 : 서로 다른 데이터베이스의 관계를 설정하고 롤업을 가져오는 것을 Parser를 통해 볼 수 있도록 추가하였습니다. 다만, Rollup 같은 경우에는 [API 문서](https://developers.notion.com/reference/property-value-object#rollup-property-values)에 나와 있듯이 type이 number, date, array 세 종류가 존재하나, 실제 데이터베이스에서 활용할 경우 array로만 나타나 array만을 지원하였습니다. 추후 number 및 date 타입으로 나타나는 경우를 발견한다면 수정해야 할 부분입니다.
2. Formula 추가 : 조건문을 통해 다른 열의 값에 따라 변화하는 수식을 Parser에 추가하였습니다.

위와 같이 변경점을 README에 반영하고 package 버전을 업데이트해 주었습니다.