### PR TITLE
Add `_parse_timestamp_value()` method. Refactor `_parse_people_value()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pynodb/__pycache__
 .DS_Store
+build
+dist

--- a/README.md
+++ b/README.md
@@ -109,4 +109,7 @@ You can get any data type using **NotionDatabaseClient** since it gives you raw 
 10. RELATION
 11. ROLLUP (only array type)
 12. FORMULA
-
+13. CREATED_TIME
+14. LAST_EDITED_TIME
+15. CREATED_BY
+16. LAST_EDITED_BY

--- a/pynodb/database_parser.py
+++ b/pynodb/database_parser.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+
 class DatabaseParser:
     def __init__(self, database):
         self.raw_database = database
@@ -17,6 +20,10 @@ class DatabaseParser:
             "relation": lambda x: self._parse_relation_value(x),
             "rollup": lambda x: self._parse_rollup_value(x),
             "formula": lambda x: self._parse_formula_value(x),
+            "created_time": lambda x: self._parse_timestamp_value(x),
+            "last_edited_time": lambda x: self._parse_timestamp_value(x),
+            "created_by": lambda x: self._parse_people_value(x),
+            "last_edited_by": lambda x: self._parse_people_value(x)
         }
         self.parsed_database = self._parse_database(database)
 
@@ -31,12 +38,17 @@ class DatabaseParser:
         return None
 
     def _parse_people_value(self, value_data):
-        if len(value_data) != 0:
-            values = []
-            for people in value_data:
-                values.append(people["name"])
-            return values
-        return None
+        if isinstance(value_data, dict):
+            return value_data["name"]
+        elif isinstance(value_data, list):
+            if len(value_data) != 0:
+                values = []
+                for people in value_data:
+                    values.append(people["name"])
+                return values
+            return None
+        else:
+            raise ValueError("Invalid people value. Must be a list or a dict.")
 
     def _parse_date_value(self, value_data):
         if value_data != None:
@@ -101,6 +113,9 @@ class DatabaseParser:
             type = value_data["type"]
             return value_data[type]
         return None
+
+    def _parse_timestamp_value(self, value_data):
+        return datetime.strptime(value_data, "%Y-%m-%dT%H:%M:%S.%fZ")
     
     def _parse_database(self, database):
         parsed_database = []


### PR DESCRIPTION
### Newly add `_parse_timestamp_value()` method to support `created_time`, `last_edited_time` column types. 
This method handles `created_time`, `last_edited_time` column types and return`datetime.datetime` object with UTC timestamp. 


### Extend `_parse_people_value()` method to support `created_by`, `last_edited_by` column types. 
Previous `_parse_people_value()` method could only parse `<list of person dict>` value_data with `people` column type. However, since `created_by`, `last_edited_by` columns have single `<person dict>` as value_data, `_parse_people_value()` could not handle those two columns. 

Instead of implementing new method such as `_parse_person_value()`, suggest `_parse_people_value()` method to not only parse `<list of person dict>` but also single `<person dict>`, checking type of the value_data. 

- isintance(value_data, dict) -> return name 
- isintance(value_data, list) -> return list of name 